### PR TITLE
メッセージ管理クラス追加

### DIFF
--- a/GitManagerApp/Const/MessageId.cs
+++ b/GitManagerApp/Const/MessageId.cs
@@ -6,15 +6,122 @@ using System.Threading.Tasks;
 
 namespace GitManagerApp.Const
 {
-    internal class MessageId
+    public class MessageId
     {
+        /// <summary>
+        /// メッセージのIDを定義する列挙型
+        /// </summary>
         public enum EnumMessageId
         {
             /// <summary>
-            /// "ブランチを変更しました。"
+            /// ブランチを変更しました。
             /// </summary>
-            BranchChanged = 1, 
-        } 
+            BranchChanged = 1,
 
+            /// <summary>
+            /// ブランチ一覧を更新します。
+            /// </summary>
+            BranchListUpdated = 2,
+
+            /// <summary>
+            /// ブランチ名とコミットメッセージの両方を入力してください。
+            /// </summary>
+            EnterBranchNameAndMessage = 3,
+
+            /// <summary>
+            /// プッシュに失敗しました。
+            /// </summary>
+            PushFailed = 4,
+
+            /// <summary>
+            /// プッシュに成功しました。
+            /// </summary>
+            PushSucceeded = 5,
+
+            /// <summary>
+            /// マージするブランチ名を入力してください。
+            /// </summary>
+            EnterBranchNameToMerge = 6,
+
+            /// <summary>
+            /// リポジトリの削除済みリモートブランチをローカルから削除しました。
+            /// </summary>
+            DeletedRemoteBranch = 7,
+
+            /// <summary>
+            /// リモートリポジトリURLを入力してください。
+            /// </summary>
+            EnterRemoteRepoUrl = 8,
+
+            /// <summary>
+            /// リモートリポジトリは最新状態です。
+            /// </summary>
+            RemoteRepoUpToDate = 9,
+
+            /// <summary>
+            /// 一時変更を破棄しました。
+            /// </summary>
+            TempChangeDiscarded = 10,
+
+            /// <summary>
+            /// 一時変更を退避しました。
+            /// </summary>
+            TempChangeStored = 11,
+
+            /// <summary>
+            /// 一時変更を適用しました。
+            /// </summary>
+            TempChangeApplied = 12,
+
+            /// <summary>
+            /// 切り替えるブランチ名を入力してください。
+            /// </summary>
+            EnterBranchNameToSwitch = 13,
+
+            /// <summary>
+            /// 削除するブランチ名を入力してください。
+            /// </summary>
+            EnterBranchNameToDelete = 14,
+
+            /// <summary>
+            /// 強制pull完了しました。
+            /// </summary>
+            ForcePullCompleted = 15,
+
+            /// <summary>
+            /// 操作を選択してください。
+            /// </summary>
+            SelectAction = 16,
+
+            /// <summary>
+            /// 新しいブランチ名を入力してください。
+            /// </summary>
+            EnterNewBranchName = 17,
+
+            /// <summary>
+            /// 新しいリモートリポジトリURLを入力してください。
+            /// </summary>
+            EnterNewRemoteRepoUrl = 18,
+
+            /// <summary>
+            /// 更新失敗しました。
+            /// </summary>
+            UpdateFailed = 19,
+
+            /// <summary>
+            /// 更新完了しました
+            /// </summary>
+            UpdateCompleted = 20,
+
+            /// <summary>
+            /// 現在の変更をStashに格納し、強制的にpullします。
+            /// </summary>
+            StashAndForcePull = 21,
+
+            /// <summary>
+            /// $指定ブランチを削除します。 : {deleteBranchName}
+            /// </summary>
+            DeleteSpecifiedBranch = 22,
+        }
     }
 }

--- a/GitManagerApp/Services/MessageManager.cs
+++ b/GitManagerApp/Services/MessageManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using GitManagerApp.Const;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,7 +7,50 @@ using System.Threading.Tasks;
 
 namespace GitManagerApp.Services
 {
-    internal class MessageManager
+    public static class MessageManager
     {
+        /// <summary>
+        /// メッセージIDとメッセージのマッピング
+        /// </summary>
+        private static readonly Dictionary<MessageId.EnumMessageId, string> Messages = new()
+        {
+            { MessageId.EnumMessageId.BranchChanged, "ブランチを変更しました。" },
+            { MessageId.EnumMessageId.BranchListUpdated, "ブランチ一覧を更新します。" },
+            { MessageId.EnumMessageId.EnterBranchNameAndMessage, "ブランチ名とコミットメッセージの両方を入力してください。" },
+            { MessageId.EnumMessageId.PushFailed, "プッシュに失敗しました。" },
+            { MessageId.EnumMessageId.PushSucceeded, "プッシュに成功しました。" },
+            { MessageId.EnumMessageId.EnterBranchNameToMerge, "マージするブランチ名を入力してください。" },
+            { MessageId.EnumMessageId.DeletedRemoteBranch, "リポジトリの削除済みリモートブランチをローカルから削除しました。" },
+            { MessageId.EnumMessageId.EnterRemoteRepoUrl, "リモートリポジトリURLを入力してください。" },
+            { MessageId.EnumMessageId.RemoteRepoUpToDate, "リモートリポジトリは最新状態です。" },
+            { MessageId.EnumMessageId.TempChangeDiscarded, "一時変更を破棄しました。" },
+            { MessageId.EnumMessageId.TempChangeStored, "一時変更を退避しました。" },
+            { MessageId.EnumMessageId.TempChangeApplied, "一時変更を適用しました。" },
+            { MessageId.EnumMessageId.EnterBranchNameToSwitch, "切り替えるブランチ名を入力してください。" },
+            { MessageId.EnumMessageId.EnterBranchNameToDelete, "削除するブランチ名を入力してください。" },
+            { MessageId.EnumMessageId.ForcePullCompleted, "強制pull完了しました。" },
+            { MessageId.EnumMessageId.SelectAction, "操作を選択してください。" },
+            { MessageId.EnumMessageId.EnterNewBranchName, "新しいブランチ名を入力してください。" },
+            { MessageId.EnumMessageId.EnterNewRemoteRepoUrl, "新しいリモートリポジトリURLを入力してください。" },
+            { MessageId.EnumMessageId.UpdateFailed, "更新失敗しました。" },
+            { MessageId.EnumMessageId.UpdateCompleted, "更新完了しました" },
+            { MessageId.EnumMessageId.StashAndForcePull, "現在の変更をStashに格納し、強制的にpullします。" },
+            { MessageId.EnumMessageId.DeleteSpecifiedBranch, "指定ブランチを削除します。 : {0}" },
+        };
+
+        /// <summary>
+        /// メッセージIDに対応するメッセージを取得します。
+        /// </summary>
+        /// <param name="id">メッセージID</param>
+        /// <param name="args">指定文字</param>
+        /// <returns></returns>
+        public static string GetMessage(MessageId.EnumMessageId id, params object[] args)
+        {
+            if (Messages.TryGetValue(id, out var template))
+            {
+                return args.Length > 0 ? string.Format(template, args) : template;
+            }
+            return $"[未定義のメッセージ: {id}]";
+        }
     }
 }


### PR DESCRIPTION
メッセージIDおよび表示文を管理するクラス MessageManager を追加しました。
Git 操作に対する通知やエラー処理のメッセージを統一的に扱うための準備です。
